### PR TITLE
Fix: correct the regex expression in rules

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: '/\.js$/',
+                test: /\.js$/,
                 exclude: /node_modules/,
                 loader: "babel-loader"
             }


### PR DESCRIPTION
The test in rules is a regex expression so quotes cause the issue and the webpack doesn't work properly. This caused my code didn't work during the course - especially when I have added sass and other rules.