### PR TITLE
Fix the issue with regex expression

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: '/\.js$/',
+                test: /\.js$/,
                 exclude: /node_modules/,
                 loader: "babel-loader"
             }


### PR DESCRIPTION
There is an issue with regex expression. The quotes are not required.
Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions