### PR TITLE
fix: fix the issue with regex expression in rules

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -9,7 +9,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: '/\.js$/',
+                test: /\.js$/,
                 exclude: /node_modules/,
                 loader: "babel-loader"
             }


### PR DESCRIPTION
There is an issue with regex expression - quotes are not required. Documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions