### PR TITLE
Fixed: changed 'npm start' to 'npm run build-dev'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone -- git@github.com:[your-user-name]/webpack-express.git --
 
 `cd` into your new folder and run:
 - ```npm install```
-- ```npm start``` to start the app
+- ```npm run build-dev``` to start the app
 - this app runs on localhost:8080, but you can of course edit that in server.js
 
 **Note:** Webpack needs to be at version 4 in order for this repo to work as expected. Webpack is automatically included at the correct version in the `package.json` provided here.


### PR DESCRIPTION
The instructed command 'npm start' cannot be called when the project hasn't been built by webpack; therefore, 'npm run build-dev' should be run instead.